### PR TITLE
Fixed Event service type fixes

### DIFF
--- a/packages/client/src/decorators/events/on-webview.decorator.ts
+++ b/packages/client/src/decorators/events/on-webview.decorator.ts
@@ -1,11 +1,11 @@
 import { OnWebView as $OnWebView } from '@altv-mango/core';
 import type { Events as SharedEvents } from '@altv/shared';
 
-export function OnWebView<E extends keyof SharedEvents.CustomClientToWebViewEvent>(id: string | number, eventName?: E): MethodDecorator;
+export function OnWebView<E extends keyof SharedEvents.CustomWebViewToClientEvent>(id: string | number, eventName?: E): MethodDecorator;
 export function OnWebView<E extends string>(
     id: string | number,
-    eventName?: Exclude<E, keyof SharedEvents.CustomClientToWebViewEvent>,
+    eventName?: Exclude<E, keyof SharedEvents.CustomWebViewToClientEvent>,
 ): MethodDecorator;
-export function OnWebView<E extends string>(id: string | number, eventName?: Exclude<E, keyof SharedEvents.CustomClientToWebViewEvent>) {
+export function OnWebView<E extends string>(id: string | number, eventName?: Exclude<E, keyof SharedEvents.CustomWebViewToClientEvent>) {
     return $OnWebView(id, eventName);
 }

--- a/packages/client/src/decorators/events/once-webview.decorator.ts
+++ b/packages/client/src/decorators/events/once-webview.decorator.ts
@@ -1,11 +1,11 @@
 import { OnceWebView as $OnceWebView } from '@altv-mango/core';
 import type { Events as SharedEvents } from '@altv/shared';
 
-export function OnceWebView<E extends keyof SharedEvents.WebViewToClientEvent>(id: string | number, eventName?: E): MethodDecorator;
+export function OnceWebView<E extends keyof SharedEvents.CustomWebViewToClientEvent>(id: string | number, eventName?: E): MethodDecorator;
 export function OnceWebView<E extends string>(
     id: string | number,
-    eventName?: Exclude<E, keyof SharedEvents.WebViewToClientEvent>,
+    eventName?: Exclude<E, keyof SharedEvents.CustomWebViewToClientEvent>,
 ): MethodDecorator;
-export function OnceWebView<E extends string>(id: string | number, eventName?: Exclude<E, keyof SharedEvents.WebViewToClientEvent>) {
+export function OnceWebView<E extends string>(id: string | number, eventName?: Exclude<E, keyof SharedEvents.CustomWebViewToClientEvent>) {
     return $OnceWebView(id, eventName);
 }

--- a/packages/client/src/interfaces/services/event-service.interface.ts
+++ b/packages/client/src/interfaces/services/event-service.interface.ts
@@ -4,7 +4,7 @@ import type { Events as ClientEvents, Player } from '@altv/client';
 export interface EventService {
     on<E extends keyof ClientEvents.CustomClientEvent>(
         eventName: E,
-        callback: (body: Parameters<ClientEvents.CustomClientEvent[E]>[0]) => ReturnType<ClientEvents.CustomClientEvent[E]>,
+        callback: (body: Parameters<ClientEvents.CustomClientEvent[E]>[0]) => void | Promise<void>,
     ): SharedEvents.ScriptEventHandler;
     on<E extends string>(
         eventName: Exclude<E, keyof ClientEvents.CustomClientEvent>,
@@ -12,7 +12,7 @@ export interface EventService {
     ): SharedEvents.ScriptEventHandler;
     once<E extends keyof ClientEvents.CustomClientEvent>(
         eventName: E,
-        callback: (body: Parameters<ClientEvents.CustomClientEvent[E]>[0]) => ReturnType<ClientEvents.CustomClientEvent[E]>,
+        callback: (body: Parameters<ClientEvents.CustomClientEvent[E]>[0]) => void | Promise<void>,
     ): SharedEvents.ScriptEventHandler;
     once<E extends string>(
         eventName: Exclude<E, keyof ClientEvents.CustomClientEvent>,
@@ -22,7 +22,7 @@ export interface EventService {
     emit<E extends string>(eventName: Exclude<E, keyof ClientEvents.CustomClientEvent>, body?: unknown): void;
     onServer<E extends keyof SharedEvents.CustomServerToPlayerEvent>(
         eventName: E,
-        callback: (body: Parameters<SharedEvents.CustomServerToPlayerEvent[E]>[0]) => ReturnType<SharedEvents.CustomServerToPlayerEvent[E]>,
+        callback: (body: Parameters<SharedEvents.CustomServerToPlayerEvent[E]>[0]) => void | Promise<void>,
     ): SharedEvents.ScriptEventHandler;
     onServer<E extends string>(
         eventName: Exclude<E, keyof SharedEvents.CustomServerToPlayerEvent>,
@@ -30,7 +30,7 @@ export interface EventService {
     ): SharedEvents.ScriptEventHandler;
     onceServer<E extends keyof SharedEvents.CustomServerToPlayerEvent>(
         eventName: E,
-        callback: (body: Parameters<SharedEvents.CustomServerToPlayerEvent[E]>[0]) => ReturnType<SharedEvents.CustomServerToPlayerEvent[E]>,
+        callback: (body: Parameters<SharedEvents.CustomServerToPlayerEvent[E]>[0]) => void | Promise<void>,
     ): SharedEvents.ScriptEventHandler;
     onceServer<E extends string>(
         eventName: Exclude<E, keyof SharedEvents.CustomServerToPlayerEvent>,
@@ -46,7 +46,7 @@ export interface EventService {
         eventName: E,
         callback: (
             body: Parameters<SharedEvents.CustomWebViewToClientEvent[E]>[0],
-        ) => ReturnType<SharedEvents.CustomWebViewToClientEvent[E]>,
+        ) => void | Promise<void>,
     ): SharedEvents.ScriptEventHandler;
     onWebView<E extends string>(
         id: string | number,
@@ -58,7 +58,7 @@ export interface EventService {
         eventName: E,
         callback: (
             body: Parameters<SharedEvents.CustomWebViewToClientEvent[E]>[0],
-        ) => ReturnType<SharedEvents.CustomWebViewToClientEvent[E]>,
+        ) => void | Promise<void>,
     ): SharedEvents.ScriptEventHandler;
     onceWebView<E extends string>(
         id: string | number,

--- a/packages/server/src/interfaces/services/event-service.interface.ts
+++ b/packages/server/src/interfaces/services/event-service.interface.ts
@@ -4,7 +4,7 @@ import type { Events as ServerEvents, Player } from '@altv/server';
 export interface EventService {
     on<E extends keyof ServerEvents.CustomServerEvent>(
         eventName: E,
-        callback: (body: Parameters<ServerEvents.CustomServerEvent[E]>[0]) => ReturnType<ServerEvents.CustomServerEvent[E]>,
+        callback: (body: Parameters<ServerEvents.CustomServerEvent[E]>[0]) => void | Promise<void>,
     ): SharedEvents.ScriptEventHandler;
     on<E extends string>(
         eventName: Exclude<E, keyof ServerEvents.CustomServerEvent>,
@@ -12,7 +12,7 @@ export interface EventService {
     ): SharedEvents.ScriptEventHandler;
     once<E extends keyof ServerEvents.CustomServerEvent>(
         eventName: E,
-        callback: (body: Parameters<ServerEvents.CustomServerEvent[E]>[0]) => ReturnType<ServerEvents.CustomServerEvent[E]>,
+        callback: (body: Parameters<ServerEvents.CustomServerEvent[E]>[0]) => void | Promise<void>,
     ): SharedEvents.ScriptEventHandler;
     once<E extends string>(
         eventName: Exclude<E, keyof ServerEvents.CustomServerEvent>,
@@ -25,7 +25,7 @@ export interface EventService {
         callback: (
             player: U,
             body: Parameters<SharedEvents.CustomPlayerToServerEvent[E]>[0],
-        ) => ReturnType<SharedEvents.CustomPlayerToServerEvent[E]>,
+        ) => void | Promise<void>,
     ): SharedEvents.ScriptEventHandler;
     onPlayer<E extends string, U extends Player>(
         eventName: Exclude<E, keyof SharedEvents.CustomPlayerToServerEvent>,
@@ -36,7 +36,7 @@ export interface EventService {
         callback: (
             player: U,
             body: Parameters<SharedEvents.CustomPlayerToServerEvent[E]>[0],
-        ) => ReturnType<SharedEvents.CustomPlayerToServerEvent[E]>,
+        ) => void | Promise<void>,
     ): SharedEvents.ScriptEventHandler;
     oncePlayer<E extends string, U extends Player>(
         eventName: Exclude<E, keyof SharedEvents.CustomPlayerToServerEvent>,
@@ -47,7 +47,7 @@ export interface EventService {
         callback: (
             player: U,
             body: Parameters<SharedEvents.CustomPlayerToServerEvent[E]>[0],
-        ) => ReturnType<SharedEvents.CustomPlayerToServerEvent[E]>,
+        ) => void | Promise<void>,
     ): SharedEvents.ScriptEventHandler;
     onRemote<E extends string, U extends Player>(
         eventName: Exclude<E, keyof SharedEvents.CustomPlayerToServerEvent>,
@@ -58,7 +58,7 @@ export interface EventService {
         callback: (
             player: U,
             body: Parameters<SharedEvents.CustomPlayerToServerEvent[E]>[0],
-        ) => ReturnType<SharedEvents.CustomPlayerToServerEvent[E]>,
+        ) => void | Promise<void>,
     ): SharedEvents.ScriptEventHandler;
     onceRemote<E extends string, U extends Player>(
         eventName: Exclude<E, keyof SharedEvents.CustomPlayerToServerEvent>,
@@ -100,7 +100,7 @@ export interface EventService {
         callback: (
             player: U,
             body: Parameters<SharedEvents.CustomWebViewToServerEvent[E]>[0],
-        ) => ReturnType<SharedEvents.CustomWebViewToServerEvent[E]>,
+        ) => void | Promise<void>,
     ): SharedEvents.ScriptEventHandler;
     onWebView<E extends string, U extends Player>(
         id: string | number,
@@ -113,7 +113,7 @@ export interface EventService {
         callback: (
             player: U,
             body: Parameters<SharedEvents.CustomWebViewToServerEvent[E]>[0],
-        ) => ReturnType<SharedEvents.CustomWebViewToServerEvent[E]>,
+        ) => void | Promise<void>,
     ): SharedEvents.ScriptEventHandler;
     onceWebView<E extends string, U extends Player>(
         id: string | number,

--- a/packages/webview/src/interfaces/event-service.interface.ts
+++ b/packages/webview/src/interfaces/event-service.interface.ts
@@ -5,7 +5,7 @@ import type { ScriptEventHandler } from './script-event-handler.interface';
 export interface EventService {
     on<E extends keyof WebViewEvents.CustomWebViewEvent>(
         eventName: E,
-        callback: (body: Parameters<WebViewEvents.CustomWebViewEvent[E]>[0]) => ReturnType<WebViewEvents.CustomWebViewEvent[E]>,
+        callback: (body: Parameters<WebViewEvents.CustomWebViewEvent[E]>[0]) => void | Promise<void>,
     ): ScriptEventHandler;
     on<E extends string>(
         eventName: Exclude<E, keyof WebViewEvents.CustomWebViewEvent>,
@@ -13,7 +13,7 @@ export interface EventService {
     ): ScriptEventHandler;
     once<E extends keyof WebViewEvents.CustomWebViewEvent>(
         eventName: E,
-        callback: (body: Parameters<WebViewEvents.CustomWebViewEvent[E]>[0]) => ReturnType<WebViewEvents.CustomWebViewEvent[E]>,
+        callback: (body: Parameters<WebViewEvents.CustomWebViewEvent[E]>[0]) => void | Promise<void>,
     ): ScriptEventHandler;
     once<E extends string>(
         eventName: Exclude<E, keyof WebViewEvents.CustomWebViewEvent>,
@@ -25,7 +25,7 @@ export interface EventService {
         eventName: E,
         callback: (
             body: Parameters<SharedEvents.CustomClientToWebViewEvent[E]>[0],
-        ) => ReturnType<SharedEvents.CustomClientToWebViewEvent[E]>,
+        ) => void | Promise<void>,
     ): ScriptEventHandler;
     onPlayer<E extends string>(
         eventName: Exclude<E, keyof SharedEvents.CustomClientToWebViewEvent>,
@@ -35,7 +35,7 @@ export interface EventService {
         eventName: E,
         callback: (
             body: Parameters<SharedEvents.CustomClientToWebViewEvent[E]>[0],
-        ) => ReturnType<SharedEvents.CustomClientToWebViewEvent[E]>,
+        ) => void | Promise<void>,
     ): ScriptEventHandler;
     oncePlayer<E extends string>(
         eventName: Exclude<E, keyof SharedEvents.CustomClientToWebViewEvent>,
@@ -50,7 +50,7 @@ export interface EventService {
         eventName: E,
         callback: (
             body: Parameters<SharedEvents.CustomServerToWebViewEvent[E]>[0],
-        ) => ReturnType<SharedEvents.CustomServerToWebViewEvent[E]>,
+        ) => void | Promise<void>,
     ): ScriptEventHandler;
     onServer<E extends string>(
         eventName: Exclude<E, keyof SharedEvents.CustomServerToWebViewEvent>,
@@ -60,7 +60,7 @@ export interface EventService {
         eventName: E,
         callback: (
             body: Parameters<SharedEvents.CustomServerToWebViewEvent[E]>[0],
-        ) => ReturnType<SharedEvents.CustomServerToWebViewEvent[E]>,
+        ) => void | Promise<void>,
     ): ScriptEventHandler;
     onceServer<E extends string>(
         eventName: Exclude<E, keyof SharedEvents.CustomServerToWebViewEvent>,


### PR DESCRIPTION
Fixed event service typings:
- OnWebView/OnceWebView decorators received wrong types
- Removed return value from webview package's event-service on... function callback functions, because they shouldn't return anything at all, that's what RPCs are for.
- Same for client package
- Same for server package