### PR TITLE
change v1 alt imports to default

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -10,7 +10,7 @@ import type {
     MultiplayerWebViewCreateOptionsOverlay,
 } from './interfaces';
 
-let sharedV1 = await import('alt-shared').catch(() => false);
+const sharedV1 = await import('alt-shared').catch(() => false);
 const multiplayerService: ClientMultiplayerService =
     sharedV1 !== false && typeof sharedV1 !== 'boolean'
         ? new ClientAltMultiplayerServceV1(sharedV1.default, (await import('alt-client')).default)

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -10,10 +10,10 @@ import type {
     MultiplayerWebViewCreateOptionsOverlay,
 } from './interfaces';
 
-const sharedV1 = await import('alt-shared').catch(() => false);
+let sharedV1 = await import('alt-shared').catch(() => false);
 const multiplayerService: ClientMultiplayerService =
     sharedV1 !== false && typeof sharedV1 !== 'boolean'
-        ? new ClientAltMultiplayerServceV1(sharedV1, await import('alt-client'))
+        ? new ClientAltMultiplayerServceV1(sharedV1.default, (await import('alt-client')).default)
         : new ClientAltMultiplayerServceV2(await import('@altv/shared'), await import('@altv/client'));
 
 class ClientAppBuilder extends AppBuilder<Guard, Interceptor, ErrorFilter> {


### PR DESCRIPTION
doesn't break anything, only needed to avoid memory leak in v1 js module which affects altv-esbuild https://xxshady.github.io/altv-esbuild/interfaces/ipluginoptions.html#altdefaultimport